### PR TITLE
Gps read returned value 0

### DIFF
--- a/libloragw/tst/test_loragw_gps.c
+++ b/libloragw/tst/test_loragw_gps.c
@@ -30,6 +30,7 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 #include <signal.h>     /* sigaction */
 #include <stdlib.h>     /* exit */
 #include <unistd.h>     /* read */
+#include <errno.h>      /* errno */
 
 #include "loragw_hal.h"
 #include "loragw_gps.h"
@@ -197,6 +198,10 @@ int main(int argc, char **argv)
     /* NMEA/UBX variables */
     enum gps_msg latest_msg; /* keep track of latest NMEA/UBX message parsed */
 
+    /* variables to limit error messages */
+    time_t last_read_warning_time = 0;
+    unsigned long suppressed_warnings = 0;
+
     /* parse command line options */
     while ((i = getopt (argc, argv, "hk:r:d:u")) != -1) {
         switch (i) {
@@ -331,7 +336,14 @@ int main(int argc, char **argv)
         /* blocking non-canonical read on serial port */
         ssize_t nb_char = read(gps_tty_dev, serial_buff + wr_idx, LGW_GPS_MIN_MSG_SIZE);
         if (nb_char <= 0) {
-            printf("WARNING: [gps] read() returned value %zd\n", nb_char);
+            time_t current_time = time(NULL);
+            if (current_time > last_read_warning_time) {
+                printf("WARNING: [gps] read() returned value %zd, errno=%d (%s). (%lu similar warnings suppressed)\n", nb_char, errno, strerror(errno), suppressed_warnings);
+                last_read_warning_time = current_time;
+                suppressed_warnings = 0;
+            } else {
+                suppressed_warnings++;
+            }
             continue;
         }
         wr_idx += (size_t)nb_char;

--- a/packet_forwarder/src/lora_pkt_fwd.c
+++ b/packet_forwarder/src/lora_pkt_fwd.c
@@ -3391,6 +3391,10 @@ void thread_gps(void) {
     char serial_buff[128]; /* buffer to receive GPS data */
     size_t wr_idx = 0;     /* pointer to end of chars in buffer */
 
+    /* variables to limit error messages */
+    time_t last_read_warning_time = 0;
+    unsigned long suppressed_warnings = 0;
+
     /* variables for PPM pulse GPS synchronization */
     enum gps_msg latest_msg; /* keep track of latest NMEA message parsed */
 
@@ -3404,7 +3408,14 @@ void thread_gps(void) {
         /* blocking non-canonical read on serial port */
         ssize_t nb_char = read(gps_tty_fd, serial_buff + wr_idx, LGW_GPS_MIN_MSG_SIZE);
         if (nb_char <= 0) {
-            MSG("WARNING: [gps] read() returned value %zd\n", nb_char);
+            time_t current_time = time(NULL);
+            if (current_time > last_read_warning_time) {
+                MSG("WARNING: [gps] read() returned value %zd, errno=%d (%s). (%lu similar warnings suppressed)\n", nb_char, errno, strerror(errno), suppressed_warnings);
+                last_read_warning_time = current_time;
+                suppressed_warnings = 0;
+            } else {
+                suppressed_warnings++;
+            }
             continue;
         }
         wr_idx += (size_t)nb_char;

--- a/readme.md
+++ b/readme.md
@@ -191,6 +191,20 @@ found in the `libtools` directory.
 
 ## 7. Changelog
 
+### v2.x
+
+#### info
+disable serial-getty@ttyS0, because the S0 will be blocked by it
+
+`systemctl disable serial-getty@ttyS0`
+
+#### changes
+
+* changed behaviour of `WARNING: [gps] read() returned value ...` with serial gps to reduce system load.
+* changed things, to get the forwarder working with debain bookworm
+* updated the possible count of gps fields
+
+
 ### v2.1.0 ###
 
 > #### Updates


### PR DESCRIPTION
changed behaviour of `WARNING: [gps] read() returned value ...` with serial gps to reduce system load.